### PR TITLE
Adding build button to GitHub Actions

### DIFF
--- a/.github/workflows/generate_db.yml
+++ b/.github/workflows/generate_db.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Useful for regenerating the database with the latest script by just pushing a button on GitHub interface.

![image](https://user-images.githubusercontent.com/852246/131040370-4f202909-bfa1-45b2-970a-f65dc0177fa0.png)
